### PR TITLE
Send response object when resolving promise for updateTagConfig

### DIFF
--- a/web/js/svc-tagging.js
+++ b/web/js/svc-tagging.js
@@ -356,7 +356,7 @@ angular.module("tagging", [])
         requestor.executeRequest("storage.tagdef.delete", params).then(function (resp) {
           if(resp.code === 200){
             localData.refreshConfigTags().then(function(){
-              deferred.resolve();
+              deferred.resolve(resp);
             });
           } else {
             deferred.resolve(resp);
@@ -377,7 +377,7 @@ angular.module("tagging", [])
         requestor.executeRequest("storage.tagdef.put", params).then(function (resp) {
           if(resp.code === 200){
             localData.refreshConfigTags().then(function(){
-              deferred.resolve();
+              deferred.resolve(resp);
             });
           } else {
             deferred.resolve(resp);


### PR DESCRIPTION
This missing parameter was causing a reload fail when saving tag definitions

@tejohnso please review
