### PR TITLE
Refresh subscription status when company changes in fullscreen

### DIFF
--- a/web/js/fullscreen/ctr-fullscreen.js
+++ b/web/js/fullscreen/ctr-fullscreen.js
@@ -2,8 +2,8 @@
 
 "use strict";
 
-var displayStorageMain = null;
-var displayTagConfigurationMain = null;
+var displayStorageMain = function() {};
+var displayTagConfigurationMain = function() {};
 
 angular.module("risevision.storage.fullscreen", ["risevision.storage.common"])
 .controller("FullScreenController", ["$scope", "$rootScope", "$http", "$location", "$timeout", "userState", "$state", "SpinnerService",
@@ -75,18 +75,14 @@ angular.module("risevision.storage.fullscreen", ["risevision.storage.common"])
 
         filesPath = filesPath ? filesPath[1] : "";
 
-        console.log("companyId", companyId);
-        console.log("filesPath", filesPath);
-
         if(filesPath.indexOf("cid=") >= 0) {
-          filesPath = "";
           $state.go("main.company-root", { companyId: companyId });
         }
         else {
           $state.go("main.company-folders", { folderPath: filesPath, companyId: companyId });
         }
-
         
+        $rootScope.$emit("storage-client:company-id-changed", companyId);
         spinnerSvc.stop();
       }
     });

--- a/web/js/subscription/ctr-subscription.js
+++ b/web/js/subscription/ctr-subscription.js
@@ -1,10 +1,14 @@
 "use strict";
 
 angular.module("risevision.storage.subscription", [])
-.controller("SubscriptionStatusController", ["$scope", "STORE_PRODUCT_CODE", "STORE_PRODUCT_ID", "$stateParams",
-function ($scope, STORE_PRODUCT_CODE, STORE_PRODUCT_ID, $stateParams) {
+.controller("SubscriptionStatusController", ["$scope", "$rootScope", "STORE_PRODUCT_CODE", "STORE_PRODUCT_ID", "$stateParams",
+function ($scope, $rootScope, STORE_PRODUCT_CODE, STORE_PRODUCT_ID, $stateParams) {
   $scope.companyId = $stateParams.companyId;
   $scope.productCode = STORE_PRODUCT_CODE;
   $scope.productId = STORE_PRODUCT_ID;
   $scope.subscriptionStatus = {};
+
+  $rootScope.$on("storage-client:company-id-changed", function(event, companyId) {
+  	$scope.companyId = companyId || $scope.companyId;
+  });
 }]);


### PR DESCRIPTION
This issue updates the companyId SubscriptionStatusController uses, which causes a refresh on component-subscription-status. The update is based on an emit on $rootScope. An alternative is having this value in a shared service. Please let me know if this solution is acceptable for you, since I think something similar will be needed for https://github.com/Rise-Vision/storage-client/issues/307

@tejohnso please review