### PR TITLE
Chore/e2e

### DIFF
--- a/test/e2e/bootstrap.js
+++ b/test/e2e/bootstrap.js
@@ -37,7 +37,6 @@ var driver = new webdriver.Builder()
   .build();
 
 var helpers = require("./bootstrap-helpers.js")(driver);
-driver.waitForObstructions = helpers.waitForObstructions;
 driver.logMessage = helpers.logMessage;
 driver.findAndClickWhenVisible = helpers.findAndClickWhenVisible;
 
@@ -49,7 +48,6 @@ driver.controlFlow().addListener(UNCAUGHT_EXCEPTION, function errorHandler(e) {
 });
 
 require("./storage-sign-in.js")(driver, args.LOCALCLIENT, args.LOCALSERVER, args.USER, args.PASSWORD);
-helpers.waitForObstructions();
 
 var filePaths = 
 [

--- a/test/e2e/upload-download.js
+++ b/test/e2e/upload-download.js
@@ -19,8 +19,8 @@ module.exports = function(driver) {
   driver.findElement(locators.fileInputElement).sendKeys(uploadFilePath);
   driver.wait(until.elementLocated(locators.fileRow), 9000, "file upload");
 
-  driver.findElement(locators.fileCheckbox).click();
-  driver.findElement(locators.downloadButton).click();
+  driver.findAndClickWhenVisible(locators.fileCheckbox);
+  driver.findAndClickWhenVisible(locators.downloadButton);
   driver.wait(function fileDownloadCheck() {
     try {
       openFileSync(downloadFilePath, "r");

--- a/web/js/modal/modal-e2e.js
+++ b/web/js/modal/modal-e2e.js
@@ -17,9 +17,7 @@ locators = {
 
 module.exports = function(driver) {
   driver.get(rvaPresentationUrl);
-  driver.wait(until.elementLocated(locators.addPresentation), 15000, "rva open");
-  driver.waitForObstructions();
-  driver.findElement(locators.addPresentation).click();
+  driver.findAndClickWhenVisible(locators.addPresentation);
 
   driver.wait(until.elementLocated(locators.addPlaceholder), 15000, "placeholder");
   driver.findElement(locators.addPlaceholder).click();

--- a/web/js/subscription/subscription-e2e.js
+++ b/web/js/subscription/subscription-e2e.js
@@ -1,40 +1,24 @@
 "use strict";
 
 var until = require("selenium-webdriver").until,
-webdriver = require("selenium-webdriver"),
 
 locators = {
   "userProfile": {"xpath": "//div[contains(@class,'user-id')]/span"},
-  "selectSubCompany": {"xpath": "//a[text()='Select Sub-Company']"},
+  "selectSubCompany": {"css": "a[ng-click='switchCompany()']"},
   "setCompany": {"css": "div[ng-click='setCompany(company)']"},
   "homeCompany": {"css": "a[ng-click='switchToMyCompany()']"},
   "trial": {"xpath": "//div[@id='subscription-status']//span[contains(.,'Free')]"},
   "subs": {"xpath": "//div[@id='subscription-status']//span[contains(.,'Subs')]"},
 };
 
-function findVisibleSelector(selector) {
-  return function findWithDriver(driver) {
-    console.log("Finding visible among " + JSON.stringify(selector));
-    var links = driver.findElements(selector);
-    return webdriver.promise.filter(links, function(link) {
-      return link.isDisplayed();
-    }).then(function(visibleLinks) {
-      return visibleLinks[0];
-    });
-  };
-}
-
 module.exports = function(driver) {
   driver.wait(until.elementLocated(locators.subs), 5000, "initial subscribed");
 
-  driver.wait(until.elementLocated(locators.userProfile), 5000, "profile");
-  driver.findElement(findVisibleSelector(locators.userProfile)).click();
+  driver.findAndClickWhenVisible(locators.userProfile);
 
-  driver.wait(until.elementLocated(locators.selectSubCompany), 5000, "drop down");
-  driver.findElement(findVisibleSelector(locators.selectSubCompany)).click();
+  driver.findAndClickWhenVisible(locators.selectSubCompany);
 
-  driver.wait(until.elementLocated(locators.setCompany), 9000, "company listing");
-  driver.findElement(locators.setCompany).click();
+  driver.findAndClickWhenVisible(locators.setCompany);
 
   driver.wait(until.elementLocated(locators.trial), 15000, "free trial");
 

--- a/web/js/tagging/tagging-modal-popup-e2e.js
+++ b/web/js/tagging/tagging-modal-popup-e2e.js
@@ -37,7 +37,7 @@ module.exports = function(driver) {
   // Display edit lookup section to add a tag
   driver.findAndClickWhenVisible(locators.editLookup);
 
-  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 7000, "wait until lookup tag window is loaded");
+  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 17000, "wait until lookup tag window is loaded");
 
   driver.findElements(locators.selectedTagdef1Value1).then(function(tags) {
     if(tags.length === 0) {
@@ -49,7 +49,7 @@ module.exports = function(driver) {
 
       driver.sleep(500);
       driver.findAndClickWhenVisible(locators.saveButton);
-      driver.wait(until.elementIsNotVisible(driver.findElement(locators.tagTypeEditingModal)), 7000, "wait until lookup tag window is closed");
+      driver.wait(until.elementIsNotVisible(driver.findElement(locators.tagTypeEditingModal)), 16000, "wait until lookup tag window is closed");
     }
   });
 
@@ -57,13 +57,13 @@ module.exports = function(driver) {
   // Display edit lookup section to remove a tag
   driver.findAndClickWhenVisible(locators.editLookup);
 
-  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 7000, "wait until lookup tag window is loaded");
+  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 15000, "wait until lookup tag window is loaded");
 
   driver.findElements(locators.selectedTagdef1Value1).then(function(tags) {
     if(tags.length === 1) {
       driver.findAndClickWhenVisible(locators.selectedTagdef1Value1);
       driver.findAndClickWhenVisible(locators.saveButton);
-      driver.wait(until.elementIsNotVisible(driver.findElement(locators.tagTypeEditingModal)), 7000, "wait until lookup tag window is closed");
+      driver.wait(until.elementIsNotVisible(driver.findElement(locators.tagTypeEditingModal)), 14000, "wait until lookup tag window is closed");
     } else {
       driver.findAndClickWhenVisible(locators.cancelButton);
     }
@@ -72,7 +72,7 @@ module.exports = function(driver) {
   // Display edit freeform section to add a freeform tag
   driver.logMessage("Section 3");
   driver.findAndClickWhenVisible(locators.editFreeform);
-  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 7000, "wait until freeform tag window is loaded");
+  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 17000, "wait until freeform tag window is loaded");
 
 
   driver.findElements(locators.freeformPlaceholder).then(function(tags) {
@@ -83,7 +83,7 @@ module.exports = function(driver) {
 
       driver.sleep(500);
       driver.findAndClickWhenVisible(locators.saveButton);
-      driver.wait(until.elementIsNotVisible(driver.findElement(locators.tagTypeEditingModal)), 7000, "wait until freeform tag window is closed");
+      driver.wait(until.elementIsNotVisible(driver.findElement(locators.tagTypeEditingModal)), 16000, "wait until freeform tag window is closed");
     } else {
       driver.findAndClickWhenVisible(locators.cancelButton);
     }
@@ -93,7 +93,7 @@ module.exports = function(driver) {
   // Display edit timeline section
   driver.findAndClickWhenVisible(locators.editTimeline);
 
-  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 7000, "wait until timeline window is loaded");
+  driver.wait(until.elementIsVisible(driver.findElement(locators.tagTypeEditingModal)), 17000, "wait until timeline window is loaded");
 
   driver.findAndClickWhenVisible(locators.saveButton);
 

--- a/web/js/tagging/tagging-settings-e2e.js
+++ b/web/js/tagging/tagging-settings-e2e.js
@@ -3,18 +3,32 @@
 var until = require("selenium-webdriver").until,
 
 locators = {
+  offCanvas: {css: "a[class*='navbar-brand'][off-canvas-toggle]"},
   tagConfiguration: { css: "a[ng-href*='displayTagConfigurationMain()']" },
   storageMain: { css: "a[ng-href*='displayStorageMain()']" },
   addTagsButton: { css: "button[ng-click='addTags()']" },
   tagdef1: { css: "div[title='tagdef1']" },
   tagdef2: { css: "div[title='tagdef2']" },
   freeform1: { css: "div[title='freeform1']" },
-  fileListItem: { css: "a[title='package.json']" }
+  fileListItem: { css: "a[title='package.json']" },
+  addTagMenu: { css: "#editTagSettings" }
 };
+
+function showOffCanvasMenuIfSmallScreen(driver) {
+  driver.call(function() {
+    driver.wait(until.elementLocated(locators.offCanvas), 1000, "off-canvas")
+    .then(function() {
+      driver.findElement(locators.offCanvas).click();
+    }).then(null, function(){
+      console.log("small screen off-canvas toggle not located");
+    });
+  });
+}
 
 module.exports = function(driver) {
   var fileListItem;
-  driver.findElement(locators.tagConfiguration).click();
+  showOffCanvasMenuIfSmallScreen(driver);
+  driver.findAndClickWhenVisible(locators.tagConfiguration);
   driver.wait(until.elementLocated(locators.addTagsButton), 5000, "add tag button");
 
   // Create a tag definition
@@ -26,13 +40,14 @@ module.exports = function(driver) {
 
     if(tagdefs.length === 0) {
       driver.findAndClickWhenVisible(locators.addTagsButton);
+      driver.wait(until.elementIsVisible(driver.findElement(locators.addTagMenu)), 4000, "add tag menu");
       
       driver.findElement(selectedTagName).sendKeys("tagdef1");
       driver.findElement(selectedTagValues).sendKeys("value1,value2,value3");
 
       driver.findAndClickWhenVisible(updateOrAddTag);
 
-      driver.wait(until.elementIsNotVisible(driver.findElement(updateOrAddTag)), 5000, "tag definition added");
+      driver.wait(until.elementIsNotVisible(driver.findElement(locators.addTagMenu)), 4000, "add tag menu");
       driver.wait(until.elementLocated(locators.tagdef1), 5000, "tag list definition refreshed");
     }
   });
@@ -46,14 +61,17 @@ module.exports = function(driver) {
 
     if(tagdefs.length === 0) {
       driver.findAndClickWhenVisible(locators.addTagsButton);
-      
+      driver.wait(until.elementIsVisible(driver.findElement(locators.addTagMenu)), 9000, "add tag menu");
+      driver.logMessage("adding tag");
+
       driver.findElement(selectedTagName).sendKeys("tagdef2");
       driver.findElement(selectedTagValues).sendKeys("valuea,valueb,valuec");
+      driver.logMessage("added tagdef2");
 
       driver.findAndClickWhenVisible(updateOrAddTag);
 
-      driver.wait(until.elementIsNotVisible(driver.findElement(updateOrAddTag)), 5000, "tag definition added");
-      driver.wait(until.elementLocated(locators.tagdef2), 5000, "tag definition list refreshed");
+      driver.wait(until.elementIsNotVisible(driver.findElement(locators.addTagMenu)), 9000, "add tag menu");
+      driver.wait(until.elementLocated(locators.tagdef2), 15000, "tag definition list refreshed");
     }
   });
 
@@ -66,8 +84,8 @@ module.exports = function(driver) {
     if(tagdefs.length === 1) {
       driver.findAndClickWhenVisible(locators.tagdef2);
 
-      driver.wait(until.elementLocated(selectedTagValues), 5000, "tag definition clicked");
       driver.wait(until.elementIsVisible(driver.findElement(locators.addTagMenu)), 5000, "tag definition clicked");
+      driver.logMessage("addTagMenu is visible");
 
       driver.findElement(selectedTagValues).getAttribute("value").then(function(value) {
         value = value.indexOf("valued") === -1 ? "valuea,valueb,valuec,valued" : "valuea,valueb,valuec";
@@ -77,7 +95,7 @@ module.exports = function(driver) {
 
         driver.findAndClickWhenVisible(updateOrAddTag);
 
-        driver.wait(until.elementIsNotVisible(driver.findElement(updateOrAddTag)), 5000, "tag definition updated");
+        driver.wait(until.elementIsNotVisible(driver.findElement(locators.addTagMenu)), 9000, "add tag menu");
         driver.wait(until.elementLocated(locators.tagdef2), 5000, "tag definition list refreshed");
       });
     }
@@ -92,13 +110,11 @@ module.exports = function(driver) {
     if(tagdefs.length === 1) {
       driver.findAndClickWhenVisible(locators.tagdef2);
 
-      driver.wait(until.elementLocated(openConfirm), 4000, "tag definition clicked");
       driver.findAndClickWhenVisible(openConfirm);
 
-      driver.wait(until.elementLocated(okButton), 5000, "tag definition clicked");
       driver.findAndClickWhenVisible(okButton);
 
-      driver.wait(until.elementLocated(locators.tagdef1), 6000, "tag definition refreshed");
+      driver.wait(until.elementIsNotVisible(driver.findElement(locators.addTagMenu)), 9000, "add tag menu");
       driver.wait(until.stalenessOf(tagdefs[0]), 7000, "tag definition deleted");
     }
   });
@@ -118,12 +134,13 @@ module.exports = function(driver) {
 
       driver.findAndClickWhenVisible(updateOrAddTag);
 
-      driver.wait(until.elementIsNotVisible(driver.findElement(updateOrAddTag)), 5000, "tag definition added");
+      driver.wait(until.elementIsNotVisible(driver.findElement(locators.addTagMenu)), 9000, "add tag menu");
       driver.wait(until.elementLocated(locators.freeform1), 5000, "tag definition list refreshed");
     }
   });
 
   driver.logMessage("Section 6");
+  showOffCanvasMenuIfSmallScreen(driver);
   driver.findAndClickWhenVisible(locators.storageMain);
   driver.wait(until.elementLocated(locators.fileListItem), 12000, "file listing");
   fileListItem = driver.findElement(locators.fileListItem);


### PR DESCRIPTION
@fjvallarino please review

findAndClickWhenVisible will
 - wait until one or more matching elements exists in the dom
 - wait until one of them is visible
 - wait until that element is enabled
 - keep clicking on it until the click succeeded

The last point takes care of things like spinners and other
elements being on top of the element to be clicked.  There's no
need to wait for obstructions in a separate call.

The pattern of calling driver.wait, then driver.findElement, then
driver.click is now completely handled in one call to
driver.findAndClickWhenVisible(selector).