### PR TITLE
Don't show add tag button until tags loaded

### DIFF
--- a/web/js/buttons/folder-move-trash-e2e.js
+++ b/web/js/buttons/folder-move-trash-e2e.js
@@ -15,8 +15,8 @@ module.exports = function(driver) {
 
   driver.findElement(locators.folderCheckbox).click();
   driver.findElement(locators.trashButton).click();
-  driver.wait(until.elementIsVisible(pendingOps), 9000, "trashing folder");
-  driver.wait(until.elementIsNotVisible(pendingOps), 9000, "folder trashed");
+  driver.wait(until.elementIsVisible(pendingOps), 18000, "trashing folder");
+  driver.wait(until.elementIsNotVisible(pendingOps), 17000, "folder trashed");
   driver.findElement(locators.trashFolder).click();
-  driver.wait(until.elementLocated(locators.folderItem), 9000, "folder in trash");
+  driver.wait(until.elementLocated(locators.folderItem), 5000, "folder in trash");
 };

--- a/web/js/tagging/ctr-tag-settings.js
+++ b/web/js/tagging/ctr-tag-settings.js
@@ -22,7 +22,7 @@ angular.module("risevision.storage.tagging")
       $scope.selectedValues = $scope.selectedTag.values;
       $scope.showAddView = false;
       $scope.showEditView = false;
-      $scope.showMainView = true;
+      $scope.showMainView = false;
       $scope.oldNameOfTag = "";
       $scope.oldValuesOfTag = "";
       $scope.duplicates = false;

--- a/web/js/tagging/tagging-settings-e2e.js
+++ b/web/js/tagging/tagging-settings-e2e.js
@@ -45,13 +45,11 @@ module.exports = function(driver) {
     var selectedTagValues = { css: "#editTagSettings input[ng-model='selectedTag.values']" };
 
     if(tagdefs.length === 0) {
-      driver.sleep(500);
       driver.findAndClickWhenVisible(locators.addTagsButton);
       
       driver.findElement(selectedTagName).sendKeys("tagdef2");
       driver.findElement(selectedTagValues).sendKeys("valuea,valueb,valuec");
 
-      driver.sleep(500);
       driver.findAndClickWhenVisible(updateOrAddTag);
 
       driver.wait(until.elementIsNotVisible(driver.findElement(updateOrAddTag)), 5000, "tag definition added");
@@ -69,6 +67,7 @@ module.exports = function(driver) {
       driver.findAndClickWhenVisible(locators.tagdef2);
 
       driver.wait(until.elementLocated(selectedTagValues), 5000, "tag definition clicked");
+      driver.wait(until.elementIsVisible(driver.findElement(locators.addTagMenu)), 5000, "tag definition clicked");
 
       driver.findElement(selectedTagValues).getAttribute("value").then(function(value) {
         value = value.indexOf("valued") === -1 ? "valuea,valueb,valuec,valued" : "valuea,valueb,valuec";


### PR DESCRIPTION
@fjvallarino please review.

The tagging settings resetView promise gets resolved after some network activity.  When it's resolved, it resets the view to the main tag settings page.  This causes problems if an e2e activity was already in progress on a different screen and expects certain screen elements to be visible.  

With this change, the Add Tag button isn't visible until that network activity has resolved.  