### PR TITLE
Add folder download feature

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "rv-widget-settings-ui-core": "https://github.com/Rise-Vision/widget-settings-ui-core.git",
     "angular-ui-router": "0.2.13",
     "angular-translate": "~2.5.2",
-    "angular-translate-loader-static-files": "~2.5.2"
+    "angular-translate-loader-static-files": "~2.5.2",
+    "jszip": "2.5.0"
   },
   "resolutions": {
     "angular": "~1.3.12",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,6 +75,7 @@ var env = process.env.NODE_ENV || "dev",
       "web/js/fullscreen/ctr-fullscreen.js",
       "web/js/external/svc-core-client.js",
       "web/js/modal/ctr-modal.js",
+      "web/js/download/svc-file-retriever.js",
       "web/js/download/svc-download.js",
       "web/js/buttons/ctr-top-buttons.js",
       "web/js/buttons/ctr-files-buttons.js",
@@ -134,6 +135,10 @@ var env = process.env.NODE_ENV || "dev",
 
     iconFiles = [
       "web/*.ico"
+    ],
+
+    libFiles = [
+      "web/lib/**/*"
     ],
 
     dataFiles = [
@@ -226,6 +231,11 @@ gulp.task("css", ["clean", "sass"], function () {
     .pipe(gulp.dest("dist/css"));
 });
 
+gulp.task("lib", ["clean"], function() {
+  return gulp.src(libFiles)
+    .pipe(gulp.dest("dist/lib"));
+});
+
 
 /* Task: config
  * Copies configuration file in place based on the current
@@ -241,7 +251,7 @@ gulp.task("config", function() {
     .pipe(gulp.dest("./web/js/config"));
 });
 
-gulp.task("build", ["clean", "config", "html", "uglify", "view", "files", "img", "css", "fonts", "locales", "icons", "data"]);
+gulp.task("build", ["clean", "config", "html", "uglify", "view", "files", "img", "css", "fonts", "locales", "icons", "lib", "data"]);
 
 
 gulp.task("test", function() {

--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,7 @@
     <script type="text/javascript" src="components/jQuery/dist/jquery.js"></script>
     <script type="text/javascript" src="components/underscore/underscore.js"></script>
     <script type="text/javascript" src="components/spin.js/spin.js"></script>
+    <script type="text/javascript" src="components/jszip/dist/jszip.js"></script>
 
     <script type="text/javascript" src="components/angular/angular.js"></script>
 
@@ -91,6 +92,7 @@
     <script type="text/javascript" src="js/throttle/svc-callout-closing-service.js"></script>
     <script type="text/javascript" src="js/throttle/ctr-container.js"></script>
     <script type="text/javascript" src="js/oauth/svc-oauth-status.js"></script>
+    <script type="text/javascript" src="js/download/svc-file-retriever.js"></script>
     <script type="text/javascript" src="js/download/svc-download.js"></script>
     <script type="text/javascript" src="js/buttons/ctr-top-buttons.js"></script>
     <script type="text/javascript" src="js/buttons/ctr-files-buttons.js"></script>

--- a/web/js/app.js
+++ b/web/js/app.js
@@ -29,8 +29,6 @@ angular.module("risevision.common.config")
   var href = window.location.href;
   var fullscreen = (window === window.top) && (href.indexOf("selector-type") === -1);
 
-  console.log("storage app config invoked!", window.location.href);
-
   $provide.value("FULLSCREEN", fullscreen);
 
   if(href.indexOf("selector-type=multiple-file") !== -1) {

--- a/web/js/buttons/ctr-files-buttons.js
+++ b/web/js/buttons/ctr-files-buttons.js
@@ -44,6 +44,7 @@ function ($scope,$rootScope, $stateParams, $window, $modal, $log, $timeout, $fil
 
   $rootScope.$on("storage-client:company-id-changed", function(event, companyId) {
     bucketName = "risemedialibrary-" + companyId;
+    folderSelfLinkUrl = STORAGE_CLIENT_API + bucketName + "/o?prefix=";
   });
 
   $window.addEventListener("beforeunload", function(e) {
@@ -74,7 +75,7 @@ function ($scope,$rootScope, $stateParams, $window, $modal, $log, $timeout, $fil
   });
 
   $scope.isDisabledDownloadButton = function() {
-    return !($scope.filesDetails.checkedCount > 0 && $scope.filesDetails.folderCheckedCount === 0) || $scope.filesDetails.localFiles === true;
+    return ($scope.filesDetails.checkedCount === 0 && $scope.filesDetails.folderCheckedCount === 0) || $scope.filesDetails.localFiles === true;
   };
 
   $scope.isDisabledCopyUrlButton = function() {
@@ -98,9 +99,6 @@ function ($scope,$rootScope, $stateParams, $window, $modal, $log, $timeout, $fil
   };
 
   $scope.downloadButtonClick = function() {
-    listSvc.filesDetails.files.forEach(function(file) {
-      if (file.name.substr(-1) === "/") {file.isChecked = false;}
-    });
     downloadSvc.downloadFiles(getSelectedFiles(), bucketName, 100);
   };
 

--- a/web/js/download/svc-download-test.js
+++ b/web/js/download/svc-download-test.js
@@ -1,4 +1,5 @@
 "use strict";
+
 function getService(serviceName) {
   var injectedService;
   inject([serviceName, function(serviceInstance) {
@@ -63,7 +64,7 @@ describe("Services: Download", function() {
     expect(dlSvc.filesDownloaded).to.equal(0);
   });
 
-  it("should download 2 files given two files and a folder", function() {
+  it("should download 2 files given two files", function() {
     var dlSvc = getService("DownloadService");
     var $timeout = getService("$timeout");
 
@@ -72,11 +73,9 @@ describe("Services: Download", function() {
       dlSvc.filesDownloaded++;
     };
 
-    dlSvc.downloadFiles([{name: "t1"},{name: "t2"},{name: "t1/"}]);
+    dlSvc.downloadFiles([{name: "t1"},{name: "t2"}]);
     $timeout.flush();
     expect(dlSvc.filesDownloaded).to.equal(1);
-    $timeout.flush();
-    expect(dlSvc.filesDownloaded).to.equal(2);
     $timeout.flush();
     expect(dlSvc.filesDownloaded).to.equal(2);
   });

--- a/web/js/download/svc-download.js
+++ b/web/js/download/svc-download.js
@@ -1,7 +1,8 @@
+/* globals JSZip */
 "use strict";
-angular.module("risevision.storage.download",[])
-.factory("DownloadService", ["$timeout", "$window", "GAPIRequestService", "$stateParams",
-function($timeout, $window, requestor, $stateParams) {
+angular.module("risevision.storage.download", ["risevision.storage.download.retriever"])
+.factory("DownloadService", ["$q", "$timeout", "$window", "GAPIRequestService", "$stateParams", "$rootScope", "FileRetrieverService",
+function($q, $timeout, $window, requestor, $stateParams, $rootScope, FileRetrieverService) {
   var svc = {};
   var downloadCount = 0;
   var iframeContainer = document.createElement("div");
@@ -10,14 +11,31 @@ function($timeout, $window, requestor, $stateParams) {
   document.body.appendChild(iframeContainer);
 
   svc.rejectedUploads = [];
+  svc.activeFolderDownloads = [];
 
-  svc.downloadURL = function(url) {
+  svc.downloadURL = function(url, fileName) {
     var hiddenIFrameID = "hiddenDownloader" + downloadCount++;
     var iframe = document.createElement("iframe");
     iframe.id = hiddenIFrameID;
     iframe.style.display = "none";
     iframeContainer.appendChild(iframe);
-    iframe.src = url;
+    iframe.src = url + "&response-content-disposition=attachment;filename=" + fileName;
+  };
+
+  svc.downloadBlob = function(blob, fileName) {
+    var a = document.createElement("a");
+    a.href = window.URL.createObjectURL(blob);
+    a.download = fileName; // Set the file name.
+    a.style.display = "none";
+    document.body.appendChild(a);
+    a.click();
+    document.body.appendChild(a);
+  };
+
+  svc.cancelFolderDownload = function(folder)  {
+    folder.cancelled = true;
+
+    svc.activeFolderDownloads.splice(svc.activeFolderDownloads.indexOf(folder), 1);
   };
 
   svc.downloadFiles = function(files, bucketName, delay) {
@@ -32,31 +50,87 @@ function($timeout, $window, requestor, $stateParams) {
 
       var file = files.shift();
       var fileName = file.name;
+
       if (fileName.substr(-1) !== "/") {
-        var params = {
-          companyId: $stateParams.companyId,
-          fileName: encodeURIComponent(file.name),
-          fileType: file.type
-        };
-        requestor.executeRequest("storage.getSignedDownloadURI", params).then(function (resp) {
-          if(resp.result) {
-            var downloadName = file.name.replace("--TRASH--/", "");
-
-            if(downloadName.indexOf("/") >= 0) {
-              downloadName = downloadName.substr(downloadName.lastIndexOf("/") + 1);
-            }
-
-            svc.downloadURL(resp.message + "&response-content-disposition=attachment;filename=" + encodeURIComponent(downloadName));
-          }
-          else {
-            console.log(resp.message);
-            file.rejectedUploadMessage = resp.message;
-            svc.rejectedUploads.push(file);
-          }
-        });
+        svc.downloadFile(file);
       }
+      else {
+        svc.downloadFolder(file);
+      }
+
       svc.downloadFiles(files, bucketName, 1000);
     }, delay, false);
+  };
+
+  svc.downloadFile = function(file) {
+    var params = {
+      companyId: $stateParams.companyId,
+      fileName: encodeURIComponent(file.name),
+      fileType: file.type
+    };
+    requestor.executeRequest("storage.getSignedDownloadURI", params).then(function (resp) {
+      if(resp.result) {
+        var downloadName = file.name.replace("--TRASH--/", "");
+
+        if(downloadName.indexOf("/") >= 0) {
+          downloadName = downloadName.substr(downloadName.lastIndexOf("/") + 1);
+        }
+
+        svc.downloadURL(resp.message, encodeURIComponent(downloadName));
+      }
+      else {
+        file.rejectedUploadMessage = resp.message;
+        svc.rejectedUploads.push(file);
+      }
+    });
+  };
+
+  svc.downloadFolder = function(folder) {
+    var params = {
+      companyId: $stateParams.companyId,
+      folderName: folder.name
+    };
+    
+    folder.cancelled = false;
+    folder.currentFile = null;
+    svc.activeFolderDownloads.push(folder);
+
+    requestor.executeRequest("storage.getFolderContents", params).then(function (resp) {
+      var zip = new JSZip();
+      var promises = [];
+
+      resp.items.forEach(function(file) {
+        if(!folder.cancelled) {
+          if(file.folder) {
+            zip.folder(file.objectId);
+          }
+          else {
+            promises.push(FileRetrieverService.retrieveFile(file.signedURL, file).then(function(response) {
+              folder.currentFile = file.objectId;
+              
+              return $q.when(response);
+            }));
+          }
+        }
+      });
+
+      $q.all(promises).then(function(responses) {
+        if(!folder.cancelled) {
+          responses.forEach(function(response) {
+            zip.file(response.userData.objectId, response.data, { binary: true });
+          });
+
+          var blob = zip.generate({type:"blob"});
+
+          svc.activeFolderDownloads.splice(svc.activeFolderDownloads.indexOf(folder), 1);
+
+          svc.downloadBlob(blob, folder.name.substr(0, folder.name.length - 1) + ".zip");
+        }
+      }, function(err) {
+        console.log(err);
+        svc.activeFolderDownloads.splice(svc.activeFolderDownloads.indexOf(folder), 1);
+      });
+    });
   };
 
   return svc;

--- a/web/js/download/svc-file-retriever.js
+++ b/web/js/download/svc-file-retriever.js
@@ -1,0 +1,33 @@
+"use strict";
+
+angular.module("risevision.storage.download.retriever",[])
+.factory("FileRetrieverService", ["$q",
+function($q) {
+  var svc = {};
+
+  svc.retrieveFile = function(url, userData) {
+    var request = new XMLHttpRequest();
+    var response = {};
+    var defer = $q.defer();
+
+    request.addEventListener("load", function() {
+      response.size = Number(request.getResponseHeader("Content-Length"));
+      response.data = new Uint8Array(request.response);
+      response.userData = userData;
+
+      defer.resolve(response);
+    }, false);
+    
+    request.addEventListener("error", function(error) {
+      defer.reject(error);
+    }, false);
+
+    request.open("GET", url);
+    request.responseType = "arraybuffer";
+    request.send();
+
+    return defer.promise;
+  };
+
+  return svc;
+}]);

--- a/web/js/files/ctr-files-test.js
+++ b/web/js/files/ctr-files-test.js
@@ -93,7 +93,7 @@ describe("FileListCtrl", function() {
 
         FileListCtrl = $controller("FileListCtrl", {
             $scope: scope, GAPIRequestService: GAPIRequestService,
-                FileListService: FileListService, $modal: modal });
+                FileListService: FileListService, $modal: modal, DownloadService: {} });
       }));
 
     afterEach(function() {

--- a/web/js/files/ctr-files.js
+++ b/web/js/files/ctr-files.js
@@ -5,11 +5,11 @@ angular.module("risevision.storage.files")
 ["$scope", "$stateParams", "$modal", "$log", "$location", "FileListService",
  "OAuthAuthorizationService", "GAPIRequestService", "OAuthStatusService",
  "$window", "STORAGE_FILE_URL", "STORAGE_CLIENT_API", "$state", "$translate",
- "FULLSCREEN", "SELECTOR_TYPE", "calloutClosingService", "filterFilter", "$timeout",
+ "FULLSCREEN", "SELECTOR_TYPE", "calloutClosingService", "filterFilter", "$timeout", "DownloadService",
 function ($scope, $stateParams, $modal, $log, $location, listSvc,
           OAuthAuthorizationService, requestSvc, OAuthStatusService,
           $window, STORAGE_FILE_URL, STORAGE_CLIENT_API, $state, $translate, FULLSCREEN, SELECTOR_TYPE,
-          calloutClosingService, filterFilter, $timeout) {
+          calloutClosingService, filterFilter, $timeout, DownloadService) {
   var bucketName = "risemedialibrary-" + $stateParams.companyId;
   var trashLabel;
   var lastClickTime = 0;
@@ -21,6 +21,7 @@ function ($scope, $stateParams, $modal, $log, $location, listSvc,
   $scope.bucketCreationStatus = {code: 202};
   $scope.currentDecodedFolder = $stateParams.folderPath ? 
                                 decodeURIComponent($stateParams.folderPath) : undefined;
+  $scope.activeFolderDownloads = DownloadService.activeFolderDownloads;
   $scope.storageFull = FULLSCREEN;
   $scope.selectorType = SELECTOR_TYPE;
   $scope.singleFileSelector = SELECTOR_TYPE === "single-file";
@@ -162,6 +163,10 @@ function ($scope, $stateParams, $modal, $log, $location, listSvc,
 
       $scope.filesDetails.checkedItemsCount += file.isChecked ? 1 : 0;
     }
+  };
+
+  $scope.cancelFolderDownload = function(folder)  {
+    DownloadService.cancelFolderDownload(folder);
   };
 
   $scope.fileIsCurrentFolder = function(file) {

--- a/web/partials/file-items.html
+++ b/web/partials/file-items.html
@@ -16,6 +16,21 @@
     </div>
   </div>
 </div>
+<div class="content-box" ng-show="activeFolderDownloads.length > 0">
+  <div class="content-box-body">
+    <div class="row" ng-repeat="folder in activeFolderDownloads">
+      <div class="col-sm-12">
+        <span>
+          <i class="fa fa-file-archive-o"></i> {{folder.name}}
+        </span>
+        <a class="add-left" href="#" ng-click="cancelFolderDownload(folder)"><span translate="common.cancel"></span></a>
+        <span class="text-muted add-left">
+          <i class="fa fa-spinner fa-spin fa-lg"></i> {{folder.currentFile}}
+        </span> 
+      </div>
+    </div>
+  </div>
+</div>
 <div class="content-box" auto-size-file-list>
 <div class="content-box-body" ng-show="statusDetails.code!==202 && !isFileListVisible()">
   <p class="text-center text-muted">No Files</p>


### PR DESCRIPTION
This implements folder download with most of the processing client side (it relies on the server to get the files and folders with the corresponding signed download URLs).

zip.js files were added inside js/lib directory because it's not published on Bower. Some of the files are minified during our standard build process, but others are left out because of how the Workers API is designed (it expects a URL pointing to the js code).

Beyond some styling issues (some space should be added between the folder list), we should probably check if initiating the download as soon as it's available is the best option (maybe a "Download" link would be more appropriate).

@tejohnso please review