### PR TITLE
Temporarily hide Cookie error messages [stage-1]

### DIFF
--- a/web/partials/file-items.html
+++ b/web/partials/file-items.html
@@ -25,7 +25,7 @@
   <span translate="storage-client.not-authorized"></span>
 </div>
 <div id="cookieTester" ng-controller="cookieTesterController as cookieController">
-  <div class="alert alert-danger" ng-show="cookieController.status.passed === false">
+  <div class="alert alert-danger" ng-hide="true">
       {{cookieController.status.message}}
   </div>
   <div ng-hide="!cookieController.status.passed">


### PR DESCRIPTION
Temporarily used ng-hide on the Cookie duplication error. Issue logged as well
https://storage-stage-1.risevision.com/

@alex-deaconu @ezequielc Thx!
